### PR TITLE
add silent option and use aiofiles to get file size

### DIFF
--- a/snappycli/client.py
+++ b/snappycli/client.py
@@ -1,14 +1,13 @@
 import sys
-import os
 
 from pathlib import Path
-from typing import (AsyncGenerator, BinaryIO)
+from typing import (AsyncGenerator)
 
-from toolz import pipe
-import httpx
 import aiofiles
-import asyncio
+import httpx
 
+from aiofiles import os as aios
+from toolz import pipe
 from tqdm import tqdm
 
 
@@ -36,50 +35,43 @@ def token(url: str, username: str, password: str) -> str:
     )
 
 
-async def _tell_aiofile(file: BinaryIO) -> int:
-    # with asyncio, file.tell() returns generator containing a future
-    done, pending = await asyncio.wait({next(file.tell())})
-    return int(done.pop().result())
-
-
-async def _get_file_size(file: BinaryIO) -> int:
-    current_pointer = await _tell_aiofile(file)
-    await file.seek(0, os.SEEK_END)
-    size = await _tell_aiofile(file)
-    await file.seek(current_pointer, os.SEEK_SET)
-
-    return size
-
-
-async def upload_bytes(
-    file: BinaryIO, chunk_size: int = 262_144_000
+async def up_bytes(            
+    filepath: Path,
+    chunk_size: int = 524_288_000
 ) -> AsyncGenerator[bytes, None]:
-    # 250 MiB == 250 * 1024 * 1024 == 262_144_000
+    # 500 MiB == 500 * 1024 * 1024 == 524,288,000
     contents = 'dummy'
     pointer = 0
-    file_size = await _get_file_size(file)
-
-    with tqdm(
-        total=file_size,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-        file=sys.stdout,
-        desc=f'Posting {file.name}'
-    ) as progress:
+    async with aiofiles.open(filepath, 'rb') as file:
         while len(contents):
             await file.seek(pointer)
             pointer += chunk_size
             contents = await file.read(chunk_size)
-            progress.update(float(chunk_size))
             yield contents
 
 
+
+async def show_progress_bar(filepath: Path) -> AsyncGenerator[bytes, None]:
+    file_stat = await aios.stat(filepath)
+    with tqdm(
+        total=file_stat.st_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        file=sys.stdout,
+        desc=f'Posting {filepath.name}'
+    ) as progress:
+        async for contents in up_bytes(filepath):
+            progress.update(float(len(contents)))
+            yield contents            
+
+
 async def _async_post_file(
-    url: str, tkn: str, filepath: Path, filedir: str = ''
+    url: str, tkn: str, filepath: Path, filedir: str = '', 
+    silent: bool = False
 ) -> httpx.Response:
-    async with aiofiles.open(filepath, 'rb') as file, \
-            httpx.AsyncClient(timeout=httpx.Timeout(
+    
+    async with httpx.AsyncClient(timeout=httpx.Timeout(
                 write=None, read=None, connect=None, pool=None)) as client:
         r = await client.post(
             url,
@@ -87,7 +79,8 @@ async def _async_post_file(
                 'filename': filepath.name,
                 'filedir' : filedir
             },
-            data=upload_bytes(file),
+            data=up_bytes(filepath) if silent \
+              else show_progress_bar(filepath),
             headers={
                 'Authorization': f'Bearer {tkn}'
             }
@@ -96,10 +89,10 @@ async def _async_post_file(
 
 
 async def async_post_file(
-    url: str, tkn: str, filepath: Path, filedir: str = ''
+    url: str, tkn: str, filepath: Path, filedir: str = '', silent: bool = False
 ) -> str:
     return pipe(
-        await _async_post_file(url, tkn, filepath, filedir),
+        await _async_post_file(url, tkn, filepath, filedir, silent),
         response_handler,
         lambda r: r['loc']
     )

--- a/snappycli/main.py
+++ b/snappycli/main.py
@@ -26,10 +26,11 @@ def exception_handler(func) -> Callable:
 
 @exception_handler
 async def _async_post_file(
-    url: str, token: str, filepath: Path, filedir: str
+    url: str, token: str, filepath: Path, filedir: str, silent: bool
 ) -> str:
     return await client.async_post_file(
-        url=url, tkn=token, filepath=filepath, filedir=filedir
+        url=url, tkn=token, filepath=filepath, filedir=filedir,
+        silent=silent
     )
 
 
@@ -99,14 +100,16 @@ def post_file(
     filedir: str = typer.Option(
         '',
         envvar='SNAPPY_FILE_DIR'
-    )
+    ),
+    silent: bool = typer.Option(False, "-s")
 ) -> None:
     typer.echo(f"""you're file is at {
     asyncio.run(_async_post_file(
         url=f'{url}/api',
         token=auth.token(auth.load()),
         filepath=filepath,
-        filedir=filedir))
+        filedir=filedir,
+        silent=silent))
     }""")
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,8 +19,9 @@ async def main():
                 os.getenv('DATA_SERVER_USERNAME'),
                 os.getenv('DATA_SERVER_PASSWORD'))
     await async_post_file(
-        f'{url}/stream', tkn,
-        Path('/home/mleader/5M.txt')
+        f'{url}/api', tkn,
+        Path('/home/mleader/1G.txt'),
+        '', True
     )
 
 


### PR DESCRIPTION
Factor out upload bytes generator from the progress bar function, and change scope of upload file to be limited to the upload byte generator function. 

Use aiofiles.os to get file size.

Add silent option to `post-file`.